### PR TITLE
get rid of RKUSB_READ_LIMIT_ADDR check

### DIFF
--- a/cmd/rockusb.c
+++ b/cmd/rockusb.c
@@ -24,12 +24,7 @@ static int rkusb_read_sector(struct ums *ums_dev,
 	struct blk_desc *block_dev = &ums_dev->block_dev;
 	lbaint_t blkstart = start + ums_dev->start_sector;
 
-	if ((blkstart + blkcnt) > RKUSB_READ_LIMIT_ADDR) {
-		memset(buf, 0xcc, blkcnt * SECTOR_SIZE);
-		return blkcnt;
-	} else {
-		return blk_dread(block_dev, blkstart, blkcnt, buf);
-	}
+	return blk_dread(block_dev, blkstart, blkcnt, buf);
 }
 
 static int rkusb_write_sector(struct ums *ums_dev,

--- a/include/rockusb.h
+++ b/include/rockusb.h
@@ -75,8 +75,6 @@ static inline int rkusb_cmd_process(struct fsg_common *common,
 #define RKUSB_CABLE_READY_TIMEOUT	60
 #define SECTOR_SIZE			0x200
 
-#define RKUSB_READ_LIMIT_ADDR	        (32 * 2048)	/* 32MB */
-
 struct rockusb {
 	struct ums *ums;
 	int ums_cnt;


### PR DESCRIPTION
There's a cap on which portion of the flash can be read using rockusb's READ_LBA command. This cap is _not_ implemented for writes however. I don't think there's any harm in removing this restriction. It currently blocks my [rockfuse](https://github.com/blasty/rockfuse) from working (for loopback mounts, for example) with the U-boot most people are using with their PBP's.